### PR TITLE
New option for setting the return-path (-rp)

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -89,6 +89,7 @@ Released on Jun-20-2015. Please look at: link:ChangeLog.mediawiki[ChangeLog].
   -w			- wait for a CR after sending the mail
   -rt  email_address	- add Reply-To header
   -rrr email_address	- request read receipts to this address
+  -rp			- return-path address",
   -ssl			- SMTP over SSL
   -starttls		- use STARTTLS if the server supports it
   -auth 		- try CRAM-MD5,LOGIN,PLAIN in that order

--- a/mailsend.h
+++ b/mailsend.h
@@ -266,7 +266,7 @@ int         show_smtp_info(char *smtp_server,int port,char *domain);
 int         send_the_mail(char *from,char *to,char *cc,char *bcc,char *sub,
                      char *smtp_server,int smtp_port,char *helo_domain,
                      char *attach_file,char *txt_msg_file,char *the_msg,
-                     int is_mime,char *rrr,char *rt,int add_dateh);
+                     int is_mime,char *rrr,char *rt,int add_dateh,char* return_path_addr);
 TheMail     *newTheMail(void);
 void        errorMsg(char *format,...);
 void        showVerbose(char *format,...);

--- a/main.c
+++ b/main.c
@@ -70,6 +70,7 @@ static void usage(void)
 "  -w                    - wait for a CR after sending the mail",
 "  -rt  email_address    - add Reply-To header",
 "  -rrr email_address    - request read receipts to this address",
+"  -rp                   - return-path address",
 "  -ssl                  - SMTP over SSL",
 "  -starttls             - use STARTTLS if the server supports it",
 "  -auth                 - try CRAM-MD5,LOGIN,PLAIN in that order",
@@ -221,7 +222,8 @@ int main(int argc,char **argv)
         *cc=NULL,
         *bcc=NULL,
         *rt=NULL,
-        *rrr=NULL;
+        *rrr=NULL,
+        *return_path_addr=NULL;
 
     g_verbose=0;
     g_connect_timeout = DEFAULT_CONNECT_TIMEOUT; /* 5 secs */
@@ -1139,6 +1141,20 @@ int main(int argc,char **argv)
                         }
                     }
                 }
+                else if (strncmp("rp",option+1,2) == 0)
+                {
+                    if (*option == '-')
+                    {
+                        i++;
+                        if (i == argc)
+                        {
+                            (void) fprintf(stderr,"Error: missing return-path address for -rp\n");
+                            rc = 1;
+                            goto ExitProcessing;
+                        }
+                        return_path_addr=argv[i];
+                    }
+                }
                 else if (strncmp("read-timeout",option+1,12) == 0)
                 {
                     if (*option == '-')
@@ -1395,7 +1411,7 @@ int main(int argc,char **argv)
 
     write_log("mailsend v%s\n",MAILSEND_VERSION);
     rc=send_the_mail(from,save_to,save_cc,save_bcc,sub,smtp_server,port,
-                helo_domain,attach_file,msg_body_file,the_msg,is_mime,rrr,rt,add_dateh);
+                helo_domain,attach_file,msg_body_file,the_msg,is_mime,rrr,rt,add_dateh,return_path_addr);
 
     if (rc == 0)
     {

--- a/smtp.c
+++ b/smtp.c
@@ -1411,7 +1411,7 @@ static int turn_on_raw_ssl(SOCKET sfd)
 int send_the_mail(char *from,char *to,char *cc,char *bcc,char *sub,
              char *smtp_server,int smtp_port,char *helo_domain,
              char *attach_file,char *txt_msg_file,char *the_msg,int is_mime,char *rrr,char *rt,
-             int add_dateh)
+             int add_dateh,char* return_path_addr)
 {
     SOCKET
         sfd;
@@ -1798,7 +1798,10 @@ int send_the_mail(char *from,char *to,char *cc,char *bcc,char *sub,
     }
 
 MailFrom:
-    rc=smtp_MAIL_FROM(from);
+    if (return_path_addr)
+        rc=smtp_MAIL_FROM(return_path_addr);
+    else
+        rc=smtp_MAIL_FROM(from);
     if (rc != 0)
         goto cleanup;
 


### PR DESCRIPTION
A new optional option -rp allows setting the return-path of the sent
e-mail. It works by using the given address when issuing the MAIL FROM
command to the smtp server. Smtp servers use this address in the
Return-Path header field.

This feature can be used to specify where bounces are sent.