### PR TITLE
Makefile.in: add missing directory dependencies

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -64,10 +64,10 @@ $(PROGNAME) : mlibs $(OBJS)
 
 install: installdirs install-bin install-man
 
-install-bin: $(BINDIR) $(PROGNAME)
+install-bin: installdirs $(PROGNAME)
 	$(INSTALL_PROGRAM) $(PROGNAME) $(BINDIR)/$(PROGNAME)
 
-install-man:
+install-man: installdirs
 	$(INSTALL_DATA) $(MANPAGE) $(MAN1DIR)
 
 installdirs:


### PR DESCRIPTION
Without the change parallel instyalls occasionally fail as:

       > install flags: -j16 install
       > install -c -m 644 doc/mailsend.1.gz $out/share/man/man1
       > install: cannot create regular file '$out/share/man/man1': No such file or directory